### PR TITLE
Connect to github

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Calculadora de Consumo Elétrico - Portugal</title>
+    <title>Calculadora Consumo Electricidade - Portugal</title>
     <meta name="description" content="Calcule o consumo elétrico dos seus eletrodomésticos em Portugal. Descubra quanto gasta por dia e mês com frigorífico, TV, máquina de lavar e mais." />
     <meta name="author" content="Lovable" />
 

--- a/src/components/ApplianceSelector.tsx
+++ b/src/components/ApplianceSelector.tsx
@@ -77,6 +77,7 @@ const ApplianceSelector: React.FC<ApplianceSelectorProps> = ({ onAddAppliance })
   const [customName, setCustomName] = useState('');
   const [power, setPower] = useState(150);
   const [hoursPerDay, setHoursPerDay] = useState([8]);
+  const [showAll, setShowAll] = useState(false);
 
   const handlePresetSelect = (preset: typeof appliancePresets[0]) => {
     setSelectedPreset(preset);
@@ -105,6 +106,19 @@ const ApplianceSelector: React.FC<ApplianceSelectorProps> = ({ onAddAppliance })
 
   const IconComponent = iconMap[selectedPreset.icon as keyof typeof iconMap];
 
+  // Compute visible presets ensuring 'Personalizado' is included in the first 12
+  const personalPreset = appliancePresets.find(p => p.name === 'Personalizado');
+  let visiblePresets = appliancePresets;
+  if (!showAll) {
+    const base = appliancePresets.slice(0, 12);
+    const hasPersonal = base.some(p => p.name === 'Personalizado');
+    if (hasPersonal || !personalPreset) {
+      visiblePresets = base;
+    } else {
+      visiblePresets = [...base.slice(0, 11), personalPreset];
+    }
+  }
+
   return (
     <Card className="brutal-border brutal-shadow p-6">
       <div className="space-y-6">
@@ -119,7 +133,7 @@ const ApplianceSelector: React.FC<ApplianceSelectorProps> = ({ onAddAppliance })
 
         {/* Appliance Grid */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          {appliancePresets.map((preset) => {
+          {visiblePresets.map((preset) => {
             const Icon = iconMap[preset.icon as keyof typeof iconMap];
             const isSelected = selectedPreset.name === preset.name;
             
@@ -150,6 +164,15 @@ const ApplianceSelector: React.FC<ApplianceSelectorProps> = ({ onAddAppliance })
             );
           })}
         </div>
+
+        {/* Ver mais / Ver menos */}
+        {appliancePresets.length > 12 && (
+          <div className="flex justify-center">
+            <Button variant="outline" onClick={() => setShowAll(!showAll)}>
+              {showAll ? 'Ver menos' : 'Ver mais'}
+            </Button>
+          </div>
+        )}
 
         {/* Custom Name Input */}
         {selectedPreset.name === 'Personalizado' && (

--- a/src/components/EnergyCalculator.tsx
+++ b/src/components/EnergyCalculator.tsx
@@ -107,10 +107,10 @@ Descubra o seu consumo em: ${window.location.origin}`;
           <div className="text-center text-primary-foreground">
             <Calculator className="w-12 h-12 mx-auto mb-4" />
             <h1 className="text-3xl font-black mb-2">
-              CALCULADORA ELÉTRICA
+              Calculadora Consumo Electricidade
             </h1>
             <p className="text-lg font-medium opacity-90">
-              Descubra quanto gastam os seus eletrodomésticos
+              Descubra quanto gastam os seus eletrodomésticos e como poupar na sua conta de eletricidade
             </p>
           </div>
         </Card>


### PR DESCRIPTION
Update UI text, make all tariff options editable, and add "Ver mais" functionality to the appliance list.

The user requested to change the title and subtitle, allow all tariff options to have customizable kWh prices, and limit the initial display of appliances to 12 with a "Ver mais" toggle, ensuring the "Personalizado" option is always visible in the initial set.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6460106-c3de-4798-bd12-6c4a50e44804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6460106-c3de-4798-bd12-6c4a50e44804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

